### PR TITLE
Correct opal link on main page

### DIFF
--- a/app/main/views/main/index.html
+++ b/app/main/views/main/index.html
@@ -26,7 +26,7 @@
     <div class='row'>
       <div class='col-md-6 col-md-offset-3'>
         <h2>Make the most of your time.</h2>
-        <p>Volt is a reactive web framework where your Ruby code runs both on the server and the client (via <a href='http://opalrb.org/' target='_blank'>opal</a>). The DOM automatically updates as the user interacts with the page, intelligently updating only the nodes that need to be changed. Data can easily be stored on the page, in a cookie, or in a database.  Take a look at the demo below, or jump into <a href='/getting_started'>getting started</a>.</p>
+        <p>Volt is a reactive web framework where your Ruby code runs both on the server and the client (via <a href='http://opalrb.com/' target='_blank'>opal</a>). The DOM automatically updates as the user interacts with the page, intelligently updating only the nodes that need to be changed. Data can easily be stored on the page, in a cookie, or in a database.  Take a look at the demo below, or jump into <a href='/getting_started'>getting started</a>.</p>
       </div>
     </div>
     <br /><br />


### PR DESCRIPTION
The .org goes to a gambling related site not the "ruby and javascript" site.